### PR TITLE
chore: remove useless postinstall script from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,6 @@
     "url": "https://github.com/cSharpBastard/mmm-nordic-electrical-spot-prices/issues"
   },
   "homepage": "https://github.com/cSharpBastard/mmm-nordic-electrical-spot-prices#readme",
-  "scripts": {
-    "postinstall": "node_modules/.bin/electron-rebuild -e ../../node_modules/electron"
-  },
   "dependencies": {
     "canvasjs": "^1.8.3",
     "dotenv": "^16.4.5",


### PR DESCRIPTION
The postinstall script is unnecessary because the module has no dependencies that require it.